### PR TITLE
dollar sign expression

### DIFF
--- a/Violet/Lexer.idr
+++ b/Violet/Lexer.idr
@@ -23,6 +23,7 @@ data VTokenKind
   | VTArrow             -- →
   | VTLambda            -- λ
   | VTDot               -- .
+  | VTDollar            -- $
   | VTIgnore            -- single line comment or whitespace
 
 export
@@ -41,6 +42,7 @@ Eq VTokenKind where
   (==) VTArrow VTArrow = True
   (==) VTLambda VTLambda = True
   (==) VTDot VTDot = True
+  (==) VTDollar VTDollar = True
   (==) _ _ = False
 
 export
@@ -59,6 +61,7 @@ Show VTokenKind where
   show VTArrow        = "→"
   show VTLambda       = "λ"
   show VTDot          = "."
+  show VTDollar       = "$"
   show VTIgnore       = "<ignore>"
 
 public export
@@ -88,6 +91,7 @@ TokenKind VTokenKind where
   tokValue VTArrow _ = ()
   tokValue VTLambda _ = ()
   tokValue VTDot _ = ()
+  tokValue VTDollar _ = ()
   tokValue VTIgnore _ = ()
 
 ||| An identifier starts from alphabet
@@ -122,6 +126,7 @@ violetTokenMap = toTokenMap [
     (exact "→", VTArrow),
     (exact "λ", VTLambda),
     (exact ".", VTDot),
+    (exact "$", VTDollar),
     (exact "(", VTOpenP),
     (exact ")", VTCloseP),
     (exact "=", VTAssign)

--- a/Violet/Parser.idr
+++ b/Violet/Parser.idr
@@ -32,13 +32,17 @@ mutual
   spine : Rule Raw
   spine = foldl1 RApp <$> some atom
 
-  -- 1. `a -> b -> c`
-  -- 2. `a b c`
-  -- notice that application should be tighter than arrow
   expr : Rule Raw
   expr = buildExpressionParser [
-    [ Infix (RPi "_" <$ match VTArrow) AssocRight
-    ]
+    -- dollar sign can use to avoid parentheses
+    -- the following expressions are same
+    -- `a $ b c d` <=> `a (b c d)`
+    -- except the arrow symbol, it's the lowest
+    -- since it's about to reorganize the code
+    [ Infix (RApp <$ match VTDollar) AssocRight ],
+    -- To be convience, thus, arrow is the lowsest symbol
+    -- For example, user might write `List a -> List b`, here `List a` is an application
+    [ Infix (RPi "_" <$ match VTArrow) AssocRight ]
   ] (spine <|> atom)
 
   tm : Rule Raw

--- a/example/test.vt
+++ b/example/test.vt
@@ -3,4 +3,4 @@ data Nat
 | suc : Nat → Nat
 ;
 let id : (A : U) → (_ : A) → A = λ A x . x;
-id Nat (suc zero)
+id Nat $ id Nat (suc zero)


### PR DESCRIPTION
with dollar sign expression, now one can write
```
a $ b c d
```
instead of
```
a (b c d)
```

This is helpful, when parenthesis is too deep.