### PR TITLE
alternative syntax

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -2,5 +2,5 @@ data Nat
 | zero : Nat
 | suc : Nat → Nat
 ;
-let id : (A : U) -> (_ : A) -> A = \ A x . x;
+let id : (A : U) -> (_ : A) -> A = \ A x => x;
 id Nat $ id Nat (suc zero)

--- a/example/test.vt
+++ b/example/test.vt
@@ -2,5 +2,5 @@ data Nat
 | zero : Nat
 | suc : Nat → Nat
 ;
-let id : (A : U) → (_ : A) → A = λ A x . x;
+let id : (A : U) -> (_ : A) -> A = \ A x . x;
 id Nat $ id Nat (suc zero)

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -12,7 +12,7 @@ mutual
   data Tm
     = SrcPos Position Tm
     | Var Name             -- x
-    | Lam Name Tm          -- λ x . t
+    | Lam Name Tm          -- λ x => t
     | App Tm Tm            -- t u
     | U                    -- U
     | Pi Name Ty Ty        -- (x : a) → b
@@ -28,7 +28,7 @@ export
 Show Tm where
   show (SrcPos _ t)        = show t
   show (Var name)        = name
-  show (Lam x t)         = "λ " ++ x ++ "." ++ show t
+  show (Lam x t)         = "λ " ++ x ++ "=>" ++ show t
   show (App t u)         = show t ++ " " ++ show u
   show U                 = "U"
   show (Pi x a b)        = "(" ++ x ++ " : " ++ show a ++ ") → " ++ show b

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -22,7 +22,7 @@ data VTokenKind
   | VTCloseP            -- )
   | VTArrow             -- → or ->
   | VTLambda            -- λ or \
-  | VTDot               -- .
+  | VTLambdaArrow       -- =>
   | VTDollar            -- $
   | VTIgnore            -- single line comment or whitespace
 
@@ -41,7 +41,7 @@ Eq VTokenKind where
   (==) VTCloseP VTCloseP = True
   (==) VTArrow VTArrow = True
   (==) VTLambda VTLambda = True
-  (==) VTDot VTDot = True
+  (==) VTLambdaArrow VTLambdaArrow = True
   (==) VTDollar VTDollar = True
   (==) _ _ = False
 
@@ -60,7 +60,7 @@ Show VTokenKind where
   show VTCloseP       = ")"
   show VTArrow        = "→"
   show VTLambda       = "λ"
-  show VTDot          = "."
+  show VTLambdaArrow  = "=>"
   show VTDollar       = "$"
   show VTIgnore       = "<ignore>"
 
@@ -90,7 +90,7 @@ TokenKind VTokenKind where
   tokValue VTCloseP _ = ()
   tokValue VTArrow _ = ()
   tokValue VTLambda _ = ()
-  tokValue VTDot _ = ()
+  tokValue VTLambdaArrow _ = ()
   tokValue VTDollar _ = ()
   tokValue VTIgnore _ = ()
 
@@ -131,7 +131,7 @@ violetTokenMap = toTokenMap [
     (exact "|", VTVerticalLine),
     (exact ":", VTColon),
     (exact ";", VTSemicolon),
-    (exact ".", VTDot),
+    (exact "=>", VTLambdaArrow),
     (exact "$", VTDollar),
     (exact "(", VTOpenP),
     (exact ")", VTCloseP),

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -109,10 +109,10 @@ comment : Lexer
 comment = is '-' <+> is '-' <+> many (isNot '\n')
 
 arrow : Lexer
-arrow = (is '-' <+> is '>') <|> (is '→')
+arrow = exact "->" <|> is '→'
 
 lambda : Lexer
-lambda = (is 'λ') <|> (exact "\\")
+lambda = (is 'λ') <|> (is '\\')
 
 keywords : List (String, VTokenKind)
 keywords = [

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -20,8 +20,8 @@ data VTokenKind
   | VTSemicolon         -- ;
   | VTOpenP             -- (
   | VTCloseP            -- )
-  | VTArrow             -- →
-  | VTLambda            -- λ
+  | VTArrow             -- → or ->
+  | VTLambda            -- λ or \
   | VTDot               -- .
   | VTDollar            -- $
   | VTIgnore            -- single line comment or whitespace
@@ -108,6 +108,12 @@ identifier = (pred isStartChar) <+> many (pred isIdChar)
 comment : Lexer
 comment = is '-' <+> is '-' <+> many (isNot '\n')
 
+arrow : Lexer
+arrow = (is '-' <+> is '>') <|> (is '→')
+
+lambda : Lexer
+lambda = (is 'λ') <|> (exact "\\")
+
 keywords : List (String, VTokenKind)
 keywords = [
   ("data", VTData),
@@ -120,11 +126,11 @@ violetTokenMap : TokenMap VToken
 violetTokenMap = toTokenMap [
     (spaces, VTIgnore),
     (comment, VTIgnore),
+    (arrow, VTArrow),
+    (lambda, VTLambda),
     (exact "|", VTVerticalLine),
     (exact ":", VTColon),
     (exact ";", VTSemicolon),
-    (exact "→", VTArrow),
-    (exact "λ", VTLambda),
     (exact ".", VTDot),
     (exact "$", VTDollar),
     (exact "(", VTOpenP),

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -75,12 +75,12 @@ mutual
     u <- tm
     pure $ RPostulate name a u
 
-  -- λ A x . x
+  -- λ A x => x
   tmLam : Rule Raw
   tmLam = do
     match VTLambda
     names <- some $ match VTIdentifier
-    match VTDot
+    match VTLambdaArrow
     body <- tm
     pure $ foldr RLam body names
 

--- a/src/Violet/Syntax.idr
+++ b/src/Violet/Syntax.idr
@@ -9,7 +9,7 @@ mutual
   data Raw
     = RSrcPos Position Raw
     | RVar Name               -- x
-    | RLam Name Raw           -- λ x . t
+    | RLam Name Raw           -- λ x => t
     | RApp Raw Raw            -- t u
     | RU                      -- U
     | RPi Name RTy RTy        -- (x : a) → b
@@ -46,7 +46,7 @@ export
 Show Raw where
   show (RSrcPos _ t)      = show t
   show (RVar name)        = name
-  show (RLam x t)         = "λ " ++ x ++ "." ++ show t
+  show (RLam x t)         = "λ " ++ x ++ "=>" ++ show t
   show (RApp t u)         = show t ++ " " ++ show u
   show RU                 = "U"
   show (RPi x a b)        = "(" ++ x ++ " : " ++ show a ++ ") → " ++ show b


### PR DESCRIPTION
Resolve #29 

- match `\` as `VTLambda`
- match `->` as `VTArrow`
- replace `.` with `=>`
