### PR TITLE
elimination parsing, syntax & core term

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -1,10 +1,20 @@
 module Test
 
+data Bool
+| True : Bool
+| False : Bool
+;
 data Nat
 | zero : Nat
 | suc : Nat → Nat
 ;
 
 let id : (A : U) -> (_ : A) -> A = \ A x => x;
+
+let zero? : Nat → Bool =
+\n => elim n
+| zero => True
+| suc _ => False
+;
 
 let main : Nat = id Nat $ id Nat (suc zero);

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -35,6 +35,7 @@ eval env tm = case tm of
   Pi x a b => VPi x (eval env a) (\u => eval (extend env x u) b)
   Let x a t u => eval (extend env x (eval env t)) u
   Postulate x a u => eval (extend env x (VVar x)) u
+  Elim t cases => ?todo1
 
 export
 quote : Env -> Val -> Tm
@@ -101,6 +102,7 @@ mutual
           newCtx = extendCtx emptyCtx x a'
       (ty, restEnvAndCtx) <- infer' (newEnv <+> env) (newCtx <+> ctx) u
       pure (ty, (newEnv, newCtx) <+> restEnvAndCtx)
+    Elim t cases => ?todo2
 
   check : Env -> Ctx -> Tm -> VTy -> checkM ()
   check env ctx t a = case (t, a) of

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -10,6 +10,11 @@ public export
 Name : Type
 Name = String
 
+public export
+data Pat
+  = PVar Name
+  | PCons Name (List Name)
+
 mutual
   ||| The Core Term of violet language
   public export
@@ -21,12 +26,18 @@ mutual
     | U                    -- U
     | Pi Name Ty Ty        -- (x : a) → b
     | Let Name Ty Tm Tm    -- let x : a = t; u
+    | Elim Tm (List (Pat, Tm))
     -- FIXME?: maybe constructor should be treated special
     | Postulate Name Ty Tm -- posulate x : a; u
 
   public export
   Ty : Type
   Ty = Tm
+
+export
+Pretty Pat where
+  pretty (PVar n) = pretty n
+  pretty (PCons h vs) = pretty h <++> hsep (map pretty vs)
 
 export
 Pretty Tm where
@@ -48,6 +59,13 @@ Pretty Tm where
     hsep [ "let", pretty x, ":", pretty a, "=", hcat [pretty t, ";"] ]
     <++> line
     <++> pretty u
+  pretty (Elim tm cases) =
+    "elim" <++> pretty tm
+    <++> line
+    <++> vsep (map prettyCase cases)
+    where
+      prettyCase : (Pat, Tm) -> Doc ann
+      prettyCase (p, t) = pipe <++> pretty p <++> "=>" <++> pretty tm
   pretty (Postulate x a u) =
     hsep ["postulate", pretty x, ":", hcat [pretty a, ";"]]
     <++> line

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -12,6 +12,7 @@ data VTokenKind
   = VTIdentifier        -- x
   | VTData              -- data
   | VTLet               -- let
+  | VTElim              -- elim
   | VTPostulate         -- postulate
   | VTUniverse          -- U
   | VTVerticalLine      -- |
@@ -32,6 +33,7 @@ Eq VTokenKind where
   (==) VTIdentifier VTIdentifier = True
   (==) VTData VTData = True
   (==) VTLet VTLet = True
+  (==) VTElim VTElim = True
   (==) VTPostulate VTPostulate = True
   (==) VTUniverse VTUniverse = True
   (==) VTVerticalLine VTVerticalLine = True
@@ -52,6 +54,7 @@ Show VTokenKind where
   show VTIdentifier   = "<identifer>"
   show VTData         = "data"
   show VTLet          = "let"
+  show VTElim         = "elim"
   show VTPostulate    = "postulate"
   show VTUniverse     = "U"
   show VTAssign       = "="
@@ -65,7 +68,7 @@ Show VTokenKind where
   show VTLambdaArrow  = "=>"
   show VTDollar       = "$"
   show VTIgnore       = "<ignore>"
-  show VTModule        = "module"
+  show VTModule       = "module"
 
 public export
 VToken : Type
@@ -83,6 +86,7 @@ TokenKind VTokenKind where
   tokValue VTIdentifier s = s
   tokValue VTData _ = ()
   tokValue VTLet _ = ()
+  tokValue VTElim _ = ()
   tokValue VTPostulate _ = ()
   tokValue VTUniverse _ = ()
   tokValue VTVerticalLine _ = ()
@@ -114,16 +118,11 @@ identifier = (pred isStartChar) <+> many (pred isIdChar)
 comment : Lexer
 comment = is '-' <+> is '-' <+> many (isNot '\n')
 
-arrow : Lexer
-arrow = exact "->" <|> is '→'
-
-lambda : Lexer
-lambda = (is 'λ') <|> (is '\\')
-
 keywords : List (String, VTokenKind)
 keywords = [
   ("data", VTData),
   ("let", VTLet),
+  ("elim", VTElim),
   ("postulate", VTPostulate),
   ("U", VTUniverse),
   ("module", VTModule)
@@ -133,12 +132,12 @@ violetTokenMap : TokenMap VToken
 violetTokenMap = toTokenMap [
     (spaces, VTIgnore),
     (comment, VTIgnore),
-    (arrow, VTArrow),
-    (lambda, VTLambda),
+    (exact "->" <|> is '→', VTArrow),
+    (is 'λ' <|> is '\\', VTLambda),
+    (exact "=>" <|> is '⇒', VTLambdaArrow),
     (exact "|", VTVerticalLine),
     (exact ":", VTColon),
     (exact ";", VTSemicolon),
-    (exact "=>", VTLambdaArrow),
     (exact "$", VTDollar),
     (exact "(", VTOpenP),
     (exact ")", VTCloseP),

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -45,7 +45,7 @@ mutual
 
   tm : Rule Raw
   tm = do
-    r <- bounds (tmLet <|> tmLam <|> tmPi <|> expr)
+    r <- bounds (tmLet <|> tmElim <|> tmLam <|> tmPi <|> expr)
     pure $ RSrcPos r
 
   -- λ A x => x
@@ -80,6 +80,25 @@ mutual
     match VTSemicolon
     u <- tm
     pure $ RLet name a t u
+  
+  -- elim n
+  -- | C x => x
+  -- | z => z
+  tmElim : Rule Raw
+  tmElim = do
+    match VTElim
+    pure $ RElim !tm !(many vcase)
+    where
+      pat : Rule PatRaw
+      pat = pure $
+            let (h ::: vs) = !(some (match VTIdentifier))
+            in if isNil vs then RPVar h else RPCons h vs
+      vcase : Rule (PatRaw, Raw)
+      vcase = do
+        match VTVerticalLine
+        p <- pat
+        match VTLambdaArrow
+        (p,) <$> tm
 
 ttmData : Rule TopLevelRaw
 ttmData = do


### PR DESCRIPTION
This PR will introduce the syntax of `elim`ination and also implement the parser for it.

When this PR is merged, users would be able to write code like

```
let zero? : Nat → Bool =
\n => elim n
| zero => True
| suc _ => False
;
```

and do pattern matching based on elimination.

related #24