### PR TITLE
new data-type syntax & reorganize top-level checking

### DIFF
--- a/example/module.vt
+++ b/example/module.vt
@@ -1,8 +1,9 @@
 module AModule
 
 data Nat
-  | zero : Nat
-  | suc : Nat → Nat;
+| zero
+| suc Nat
+;
 
 data SomethingElse;
 

--- a/example/module_failed.vt
+++ b/example/module_failed.vt
@@ -1,8 +1,9 @@
 module AModule
 
 data Nat
-  | zero : Nat
-  | suc : Nat → Nat;
+| zero
+| suc Nat
+;
 
 data SomethingElse;
 

--- a/example/test.vt
+++ b/example/test.vt
@@ -1,20 +1,20 @@
 module Test
 
 data Bool
-| True : Bool
-| False : Bool
+| True
+| False
 ;
 data Nat
-| zero : Nat
-| suc : Nat → Nat
+| zero
+| suc Nat
 ;
 
 let id : (A : U) -> (_ : A) -> A = \ A x => x;
 
-let zero? : Nat → Bool =
-\n => elim n
-| zero => True
-| suc _ => False
-;
+-- let zero? : Nat → Bool =
+-- \n => elim n
+-- | zero => True
+-- | suc _ => False
+-- ;
 
 let main : Nat = id Nat $ id Nat (suc zero);

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -122,8 +122,6 @@ mutual
         t' <- runEval eval env t
         let env' = extendEnv env x t'
             ctx' = extendCtx ctx x a'
-        updateEnv x t'
-        updateCtx x a'
         ty <- infer env' ctx' u
         pure ty
       go (Elim t cases) = ?todo2
@@ -144,8 +142,6 @@ mutual
         check env ctx t a'
         let env' = (extendEnv env x !(runEval eval env t))
             ctx' = (extendCtx ctx x a')
-        updateEnv x !(runEval eval env t)
-        updateCtx x a'
         check env' ctx' u a'
       go _ _ = do
         tty <- infer env ctx t

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -59,7 +59,7 @@ runEval f env a = do
   pure b
 
 mutual
-  export partial
+  export
   checkModule : Check e => List Definition -> App e CheckState
   checkModule [] = getState
   checkModule (d :: ds) = go d *> checkModule ds

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -27,15 +27,23 @@ mutual
     | Pi Name Ty Ty        -- (x : a) → b
     | Let Name Ty Tm Tm    -- let x : a = t; u
     | Elim Tm (List (Pat, Tm))
-    -- FIXME?: maybe constructor should be treated special
-    | Postulate Name Ty Tm -- posulate x : a; u
-    -- data
-    | Sum Name (List (Name, List Ty))
-    | Intro Name Ty Tm
 
   public export
   Ty : Type
   Ty = Tm
+
+  public export
+  data DataCase = C Name (List Ty)
+
+  public export
+  data Definition
+    = DSrcPos (WithBounds Definition)
+    -- data Nat
+    -- | zero
+    -- | suc Nat
+    | Data Name (List DataCase)
+    -- let x : a = t;
+    | Def Name Ty Tm
 
 export
 Pretty Pat where
@@ -69,12 +77,3 @@ Pretty Tm where
     where
       prettyCase : (Pat, Tm) -> Doc ann
       prettyCase (p, t) = pipe <++> pretty p <++> "=>" <++> pretty tm
-  pretty (Postulate x a u) =
-    hsep ["postulate", pretty x, ":", hcat [pretty a, ";"]]
-    <++> line
-    <++> pretty u
-  pretty (Intro x t u) = spaces 2 <++> hsep ["constructor", pretty x] <++> line <++> pretty u
-  pretty (Sum x cases) = vsep (hsep ["data", pretty x] :: map pp cases)
-  where
-    pp : (Name, List Ty) -> Doc ann
-    pp (x, ts) = "|" <++> pretty x <++> hsep (map pretty ts)

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -31,7 +31,7 @@ mutual
     | Postulate Name Ty Tm -- posulate x : a; u
     -- data
     | Sum Name (List (Name, List Ty))
-    | Intro Name Tm
+    | Intro Name Ty Tm
 
   public export
   Ty : Type
@@ -73,7 +73,7 @@ Pretty Tm where
     hsep ["postulate", pretty x, ":", hcat [pretty a, ";"]]
     <++> line
     <++> pretty u
-  pretty (Intro x u) = spaces 2 <++> hsep ["constructor", pretty x] <++> line <++> pretty u
+  pretty (Intro x t u) = spaces 2 <++> hsep ["constructor", pretty x] <++> line <++> pretty u
   pretty (Sum x cases) = vsep (hsep ["data", pretty x] :: map pp cases)
   where
     pp : (Name, List Ty) -> Doc ann

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -29,6 +29,9 @@ mutual
     | Elim Tm (List (Pat, Tm))
     -- FIXME?: maybe constructor should be treated special
     | Postulate Name Ty Tm -- posulate x : a; u
+    -- data
+    | Sum Name (List (Name, List Ty))
+    | Intro Name Tm
 
   public export
   Ty : Type
@@ -70,3 +73,5 @@ Pretty Tm where
     hsep ["postulate", pretty x, ":", hcat [pretty a, ";"]]
     <++> line
     <++> pretty u
+  pretty (Intro x u) = spaces 2 <++> hsep ["constructor", pretty x] <++> line <++> pretty u
+  pretty _ = emptyDoc

--- a/src/Violet/Core/Val.idr
+++ b/src/Violet/Core/Val.idr
@@ -11,6 +11,8 @@ mutual
     | VLam Name (Val -> Val)
     | VPi Name VTy (Val -> Val)
     | VU
+    | VSum Name (List (Name, List VTy))
+    | VConstructor Name (List Val)
 
   public export
   VTy : Type

--- a/src/Violet/Core/Val.idr
+++ b/src/Violet/Core/Val.idr
@@ -50,7 +50,7 @@ eval env tm = case tm of
   Postulate x a u => eval (extendEnv env x (VVar x)) u
   Elim t cases => ?todo1
   Sum x cases => pure $ VSum x $ map (\(name, ts) => (name, rights $ map (eval env) ts)) cases
-  Intro x u => eval (extendEnv env x (VConstructor x [])) u
+  Intro x _ u => eval (extendEnv env x (VConstructor x [])) u
 
 export
 fresh : Env -> Name -> Name
@@ -72,7 +72,7 @@ quote env v = case v of
     let x = fresh env x
     pure $ Pi x !(quote env a) !(quote (extendEnv env x (VVar x)) !(b (VVar x)))
   VU => pure U
-  VSum x cases => pure $ Sum x $ map (\(name, ts) => (name, rights $ map (quote env) ts)) cases
+  VSum x cases => pure $ Var x
   VConstructor x vs => pure $ foldl Apply (Var x) $ rights $ map (quote env) vs
 
 nf : Env -> Tm -> Either EvalError Tm

--- a/src/Violet/Error/Check.idr
+++ b/src/Violet/Error/Check.idr
@@ -11,12 +11,16 @@ public export
 data CheckErrorKind
   = NoVar String
   | InferLam Tm
+  | NotExpectedType Name
+  | NoConstructor Name
   | BadApp Tm
   | TypeMismatch Tm Tm
 
 prettyCheckErrorKind : CheckErrorKind -> Doc AnsiStyle
 prettyCheckErrorKind (NoVar name) = annBold $ annColor Red $ hsep ["variable:", pretty name, "not found"]
-prettyCheckErrorKind (InferLam tm) = annBold $ annColor Red $ hcat ["cannot inference lambda: ", pretty tm]
+prettyCheckErrorKind (InferLam tm) = annBold $ annColor Red $ hsep ["cannot inference lambda:", pretty tm]
+prettyCheckErrorKind (NotExpectedType x) = annBold $ annColor Red $ hcat ["expected", pretty x, ",but not"]
+prettyCheckErrorKind (NoConstructor name) = annBold $ annColor Red $ hcat ["no constructor called", pretty name]
 prettyCheckErrorKind (BadApp tm) = annBold $ annColor Red $ hcat ["bad app on: ", pretty tm]
 prettyCheckErrorKind (TypeMismatch t1 t2) = vcat
   [ annBold $ annColor Red $ "type mismatched"

--- a/src/Violet/Error/Check.idr
+++ b/src/Violet/Error/Check.idr
@@ -10,19 +10,12 @@ public export
 data CheckErrorKind
   = NoVar String
   | InferLam Tm
-  | NotExpectedType Name Tm
-  | NoConstructor Name
   | BadApp Tm
   | TypeMismatch Tm Tm
 
 prettyCheckErrorKind : CheckErrorKind -> Doc AnsiStyle
 prettyCheckErrorKind (NoVar name) = annBold $ annColor Red $ hsep ["variable:", pretty name, "not found"]
 prettyCheckErrorKind (InferLam tm) = annBold $ annColor Red $ hsep ["cannot inference lambda:", pretty tm]
-prettyCheckErrorKind (NotExpectedType x tm) = annBold $ annColor Red $
-  hsep ["expected", hcat [pretty x, ","], "but not"]
-  <++> line
-  <++> hsep ["term", pretty tm]
-prettyCheckErrorKind (NoConstructor name) = annBold $ annColor Red $ hsep ["no constructor called", pretty name]
 prettyCheckErrorKind (BadApp tm) = annBold $ annColor Red $ hsep ["bad app on:", pretty tm]
 prettyCheckErrorKind (TypeMismatch t1 t2) = vcat
   [ annBold $ annColor Red $ "type mismatched"

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -119,15 +119,6 @@ ttmData = do
       a <- many tm
       pure (name, a)
 
-ttmPostulate : Rule TopLevelRaw
-ttmPostulate = do
-  match VTPostulate
-  name <- match VTIdentifier
-  match VTColon
-  a <- tm
-  match VTSemicolon
-  pure $ TPostulate name a
-
 -- let x : a = t
 ttmLet : Rule TopLevelRaw
 ttmLet = do
@@ -141,7 +132,7 @@ ttmLet = do
   pure $ TLet name a t
 
 ttm : Rule TopLevelRaw
-ttm = TSrcPos <$> bounds (ttmData <|> ttmPostulate <|> ttmLet)
+ttm = TSrcPos <$> bounds (ttmData <|> ttmLet)
 
 export
 ruleTm : Rule Raw

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -110,14 +110,13 @@ ttmData = do
   name <- match VTIdentifier
   caseList <- many pCase
   match VTSemicolon
-  pure $ TData name caseList
+  pure $ TData name [] caseList
   where
-    pCase : Rule (Name, RTy)
+    pCase : Rule (Name, List RTy)
     pCase = do
       match VTVerticalLine
       name <- match VTIdentifier
-      match VTColon
-      a <- tm
+      a <- many tm
       pure (name, a)
 
 ttmPostulate : Rule TopLevelRaw
@@ -142,7 +141,7 @@ ttmLet = do
   pure $ TLet name a t
 
 ttm : Rule TopLevelRaw
-ttm = ttmData <|> ttmPostulate <|> ttmLet
+ttm = TSrcPos <$> bounds (ttmData <|> ttmPostulate <|> ttmLet)
 
 export
 ruleTm : Rule Raw

--- a/src/Violet/Syntax.idr
+++ b/src/Violet/Syntax.idr
@@ -74,7 +74,7 @@ go : (next : Tm) -> TopLevelRaw -> Tm
 go next (TLet x a t) = Let x (cast a) (cast t) next
 go next (TPostulate x a) = Postulate x (cast a) next
 go next (TData x _ cases) = foldl
-  (\a, (x, _) => \u => a (Intro x u))
+  (\a, (x', _) => \u => a (Intro x' (Var x) u))
   (\u => Let x U (Sum x (map (\(x, ts) => (x, map cast ts)) cases)) u)
   cases
   next


### PR DESCRIPTION
1. reorganize the top-level checking that will handle definition one by one
2. introduce new data-type syntax, preparing for simpler indexed data type

related #51 