### PR TITLE
more carefulness top-level syntax

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -8,17 +8,15 @@ data Nat
 | zero
 | suc Nat
 
-def id : (A : U) -> (_ : A) -> A = \ A x => x
+def id (A : U) (x : A) : A => x
 
-def zero? : Nat → Bool =
-\n => elim n
+def zero? (n : Nat) : Bool => elim n
 | zero => True
 | suc _ => False
 
-def not : Bool → Bool =
-\b => elim b
+def not (b : Bool) : Bool => elim b
 | True => False
 | False => True
 
-def main : Bool = not $ not $ zero? $
+def main : Bool => not $ not $ zero? $
   id Nat $ id Nat (suc zero)

--- a/example/test.vt
+++ b/example/test.vt
@@ -3,24 +3,22 @@ module Test
 data Bool
 | True
 | False
-;
+
 data Nat
 | zero
 | suc Nat
-;
 
-let id : (A : U) -> (_ : A) -> A = \ A x => x;
+def id : (A : U) -> (_ : A) -> A = \ A x => x
 
-let zero? : Nat → Bool =
+def zero? : Nat → Bool =
 \n => elim n
 | zero => True
 | suc _ => False
-;
 
-let not : Bool → Bool =
+def not : Bool → Bool =
 \b => elim b
 | True => False
 | False => True
-;
 
-let main : Bool = not $ not $ zero? $ id Nat $ id Nat (suc zero);
+def main : Bool = not $ not $ zero? $
+  id Nat $ id Nat (suc zero)

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -10,6 +10,7 @@ import Data.SortedSet
 public export
 data VTokenKind
   = VTIdentifier        -- x
+  | VTDef               -- def
   | VTData              -- data
   | VTLet               -- let
   | VTElim              -- elim
@@ -31,6 +32,7 @@ data VTokenKind
 export
 Eq VTokenKind where
   (==) VTIdentifier VTIdentifier = True
+  (==) VTDef VTDef = True
   (==) VTData VTData = True
   (==) VTLet VTLet = True
   (==) VTElim VTElim = True
@@ -52,6 +54,7 @@ Eq VTokenKind where
 export
 Show VTokenKind where
   show VTIdentifier   = "<identifer>"
+  show VTDef          = "def"
   show VTData         = "data"
   show VTLet          = "let"
   show VTElim         = "elim"
@@ -84,6 +87,7 @@ TokenKind VTokenKind where
   TokType _ = ()
 
   tokValue VTIdentifier s = s
+  tokValue VTDef _ = ()
   tokValue VTData _ = ()
   tokValue VTLet _ = ()
   tokValue VTElim _ = ()
@@ -120,6 +124,7 @@ comment = is '-' <+> is '-' <+> many (isNot '\n')
 
 keywords : List (String, VTokenKind)
 keywords = [
+  ("def", VTDef),
   ("data", VTData),
   ("let", VTLet),
   ("elim", VTElim),

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -118,16 +118,25 @@ ttmData = do
       a <- many tm
       pure (name, a)
 
--- let x : a = t
+-- def x (xi : Ti) : T =>
+--   u
 ttmDef : Rule TopLevelRaw
 ttmDef = do
   match VTDef
   name <- match VTIdentifier
+  tele <- many $ parens binding
   match VTColon
   a <- tm
-  match VTAssign
+  match VTLambdaArrow
   t <- tm
-  pure $ TDef name a t
+  pure $ TDef name tele a t
+  where
+    binding : Rule (Name, RTy)
+    binding = do
+      name <- match VTIdentifier
+      match VTColon
+      ty <- tm
+      pure (name, ty)
 
 ttm : Rule TopLevelRaw
 ttm = TSrcPos <$> bounds (ttmData <|> ttmDef)

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -84,25 +84,23 @@ mutual
     match VTSemicolon
     u <- tm
     pure $ RLet name a t u
-  
+
+  patRule : Rule PatRaw
+  patRule = pure $ let (h ::: vs) = !(some (match VTIdentifier))
+    in if isNil vs then RPVar h else RPCons h vs
+  caseRule : Rule (PatRaw, Raw)
+  caseRule = do
+    match VTVerticalLine
+    p <- patRule
+    match VTLambdaArrow
+    (p,) <$> tm
   -- elim n
   -- | C x => x
   -- | z => z
   tmElim : Rule Raw
   tmElim = do
     match VTElim
-    pure $ RElim !tm !(many vcase)
-    where
-      pat : Rule PatRaw
-      pat = pure $
-            let (h ::: vs) = !(some (match VTIdentifier))
-            in if isNil vs then RPVar h else RPCons h vs
-      vcase : Rule (PatRaw, Raw)
-      vcase = do
-        match VTVerticalLine
-        p <- pat
-        match VTLambdaArrow
-        (p,) <$> tm
+    pure $ RElim !tm !(many caseRule)
 
 ttmData : Rule TopLevelRaw
 ttmData = do

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -109,7 +109,6 @@ ttmData = do
   match VTData
   name <- match VTIdentifier
   caseList <- many pCase
-  match VTSemicolon
   pure $ TData name [] caseList
   where
     pCase : Rule (Name, List RTy)
@@ -120,19 +119,18 @@ ttmData = do
       pure (name, a)
 
 -- let x : a = t
-ttmLet : Rule TopLevelRaw
-ttmLet = do
-  match VTLet
+ttmDef : Rule TopLevelRaw
+ttmDef = do
+  match VTDef
   name <- match VTIdentifier
   match VTColon
   a <- tm
   match VTAssign
   t <- tm
-  match VTSemicolon
-  pure $ TLet name a t
+  pure $ TDef name a t
 
 ttm : Rule TopLevelRaw
-ttm = TSrcPos <$> bounds (ttmData <|> ttmLet)
+ttm = TSrcPos <$> bounds (ttmData <|> ttmDef)
 
 export
 ruleTm : Rule Raw

--- a/src/Violet/Syntax.idr
+++ b/src/Violet/Syntax.idr
@@ -11,6 +11,19 @@ data PatRaw
   | RPCons Name (List Name)
 
 mutual
+  ||| The Raw top-level definition of violet
+  public export
+  data TopLevelRaw
+    = TSrcPos (WithBounds TopLevelRaw)
+    -- def x : a => t
+    | TDef Name RTy Raw
+    -- data Nat
+    -- | zero
+    -- | suc Nat
+    | TData Name (List RTy)
+        -- constructors
+        (List (Name, (List RTy)))
+
   ||| The Raw expression of violet
   public export
   data Raw
@@ -33,18 +46,6 @@ mutual
   public export
   RTy : Type
   RTy = Raw
-
-||| The Raw top-level definition of violet
-public export
-data TopLevelRaw
-  = TSrcPos (WithBounds TopLevelRaw)
-  | TLet Name RTy Raw       -- let x : a = t
-  -- data Nat
-  -- | zero
-  -- | suc Nat
-  | TData Name (List RTy)
-      -- constructors
-      (List (Name, (List RTy)))
 
 public export
 data ModuleInfoRaw = MkModuleInfoRaw Name
@@ -71,7 +72,7 @@ Cast Raw Tm where
 export
 Cast TopLevelRaw Definition where
   cast (TSrcPos top) = DSrcPos $ MkBounded (cast top.val) True top.bounds
-  cast (TLet x a t) = Def x (cast a) (cast t)
+  cast (TDef x a t) = Def x (cast a) (cast t)
   cast (TData x _ cases) = Data x (map toCase cases)
     where
       toCase : (Name, (List RTy)) -> DataCase


### PR DESCRIPTION
* remove `;` from top-level syntax
* redesign the top-level define, from `let x : a = t` to `def x (x_i : T_i) : T => u`

resolve #60, the `elim` missing multiple expressions/patterns problem will be another PR