### PR TITLE
group parameters

### DIFF
--- a/example/leibniz.vt
+++ b/example/leibniz.vt
@@ -1,10 +1,10 @@
 module Leibniz
 
-def Eq (A : U) (x : A) (y : A) : U =>
+def Eq (A : U) (x y : A) : U =>
 	(P : A -> U) -> P x -> P y
 
 def refl (A : U) (x : A) : Eq A x x =>
 	λ _ Px => Px
 
-def sym (A : U) (x : A) (y : A) : Eq A x y -> Eq A y x =>
+def sym (A : U) (x y : A) : Eq A x y -> Eq A y x =>
 	λ p => p (λ y => Eq A y x) (refl A x)

--- a/example/test.vt
+++ b/example/test.vt
@@ -14,6 +14,10 @@ def zero? (n : Nat) : Bool => elim n
 | zero => True
 | suc _ => False
 
+def plus (n m : Nat) : Nat => elim n
+| zero  => m
+| suc n => suc $ plus n m
+
 def not (b : Bool) : Bool => elim b
 | True => False
 | False => True

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -99,7 +99,7 @@ mutual
 				state <- getState
 				check state.topEnv state.topCtx a VU
 				a' <- runEval eval state.topEnv a
-				check state.topEnv state.topCtx t a'
+				check (extendEnv state.topEnv x (VVar x)) (extendCtx state.topCtx x a') t a'
 				t' <- runEval eval state.topEnv t
 				updateEnv x t'
 				updateCtx x a'


### PR DESCRIPTION
For example, we can now write

    def foo (a : A) -> (b : A) : A => a

to

    def foo (a b : A) : A => a

resolve #57

Signed-off-by: Lîm Tsú-thuàn <dannypsnl@gmail.com>