### PR TITLE
separate global & local environment for recursive

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -16,11 +16,10 @@ def zero? (n : Nat) : Bool => elim n
 
 def plus (n m : Nat) : Nat => elim n
 | zero  => m
-| suc n => suc $ plus n m
+| suc n1 => suc $ plus n1 m
 
 def not (b : Bool) : Bool => elim b
 | True => False
 | False => True
 
-def main : Bool => not $ not $ zero? $
-	id Nat $ id Nat (suc zero)
+def main : Nat => plus (suc $ suc zero) zero

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -23,12 +23,13 @@ parseMod source = do
 checkMod : Has [PrimIO] e => String -> String -> List Definition -> App e CheckState
 checkMod filename source defs = do
 	let ctx = (ctxFromFile filename source)
-	new (checkState ctx emptyEnv) $ checkModule defs `handleErr` putErr prettyCheckError
+	new (checkState ctx) $ checkModule defs `handleErr` putErr prettyCheckError
 
 putCtx : PrimIO e => CheckState -> App e ()
 putCtx state = do
+	let env = MkEnv state.topEnv []
 	for_ (reverse state.topCtx.map) $ \(name, ty) => do
-		v <- new state (runEval quote state.topEnv ty) `handleErr` putErr prettyCheckError
+		v <- new state (runEval quote env ty) `handleErr` putErr prettyCheckError
 		primIO $ putDoc $ (annotate bold $ pretty name)
 			<++> ":"
 			<++> (annBold $ annColor Blue $ pretty v)
@@ -41,8 +42,9 @@ replLoop = do
 	let tm = cast raw
 	state <- get CheckState
 	t <- infer' tm `handleErr` putErr prettyCheckError
-	ty <- runEval quote state.topEnv t `handleErr` putErr prettyCheckError
-	v <- runEval nf state.topEnv tm `handleErr` putErr prettyCheckError
+	let env = MkEnv state.topEnv []
+	ty <- runEval quote env t `handleErr` putErr prettyCheckError
+	v <- runEval nf env tm `handleErr` putErr prettyCheckError
 	primIO $ putDoc $ hsep [annBold (pretty v), ":", (annBold $ annColor Blue $ pretty ty)]
 	replLoop
 

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -179,8 +179,9 @@ mutual
 						goCase env ctx cs !(maybeConv env rhs_ty new_rhs_ty) cases
 					goCase env ctx cs rhs_ty ((PCons head vars, rhs) :: cases) = do
 						tys <- getTelescope cs head
-						let env' = { local := zip vars (map VVar vars) ++ env.local } env
-						let ctx' = extendCtxWithBinds ctx (zip vars tys)
+						let patternEnv = vars `zip` (map VVar vars)
+						let env' = { local := patternEnv ++ env.local } env
+						let ctx' = extendCtxWithBinds ctx (vars `zip` tys)
 						new_rhs_ty <- infer env' ctx' rhs
 						goCase env ctx cs !(maybeConv env rhs_ty new_rhs_ty) cases
 					goCase env ctx cs rhs_ty [] = pure rhs_ty

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -76,4 +76,4 @@ Pretty Tm where
 		<++> vsep (map prettyCase cases)
 		where
 			prettyCase : (Pat, Tm) -> Doc ann
-			prettyCase (p, t) = pipe <++> pretty p <++> "=>" <++> pretty tm
+			prettyCase (p, t) = pipe <++> pretty p <++> "=>" <++> pretty t

--- a/src/Violet/Core/Val.idr
+++ b/src/Violet/Core/Val.idr
@@ -45,11 +45,8 @@ extendEnv env x v = { local := (x, v) :: env.local } env
 export
 lookupEnv : Name -> Env -> Either EvalError Val
 lookupEnv x env = do
-	Just v <- pure $ lookup x env.local
-		| Nothing => do
-			Just v <- pure $ lookup x env.global
-				| Nothing => Left $ NoVar x
-			pure v
+	Just v <- pure $ lookup x env.local <|> lookup x env.global
+		| Nothing => Left $ NoVar x
 	pure v
 
 export

--- a/src/Violet/Error/Eval.idr
+++ b/src/Violet/Error/Eval.idr
@@ -15,4 +15,4 @@ export
 prettyEvalError : EvalError -> Doc AnsiStyle
 prettyEvalError (NoVar name) = annBold $ annColor Red $ hsep ["variable:", pretty name, "not found"]
 prettyEvalError (BadSpine tm) = annBold $ annColor Red $ hsep ["bad spine on:", pretty tm]
-prettyEvalError (OutOfCase) = annBold $ annColor Red $ "pattern matching out of case"
+prettyEvalError OutOfCase = annBold $ annColor Red $ "pattern matching out of case"


### PR DESCRIPTION
smaller double env compare to previous PR
1. having concept about global & local env
2. introduce `VCtor` to store constructor properly in evaluation
3. The infinite loop is not about global recursive, but about access bad pattern variable! This get fix but having problem with destructing constructor with more than one arguments

resolve #67 

Signed-off-by: Lîm Tsú-thuàn <dannypsnl@gmail.com>