### PR TITLE
`elim` multiple targets

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -1,8 +1,8 @@
 module Test
 
 data Bool
-| True
-| False
+| true
+| false
 
 data Nat
 | zero
@@ -11,15 +11,15 @@ data Nat
 def id (A : U) (x : A) : A => x
 
 def zero? (n : Nat) : Bool => elim n
-| zero => True
-| suc _ => False
+| zero => true
+| suc _ => false
 
 def plus (n m : Nat) : Nat => elim n, m
 | zero, m => m
 | suc n, m => suc $ plus n m
 
 def not (b : Bool) : Bool => elim b
-| True => False
-| False => True
+| true => false
+| false => true
 
 def main : Nat => plus (suc $ suc zero) zero

--- a/example/test.vt
+++ b/example/test.vt
@@ -14,9 +14,9 @@ def zero? (n : Nat) : Bool => elim n
 | zero => True
 | suc _ => False
 
-def plus (n m : Nat) : Nat => elim n
-| zero => m
-| suc n => suc $ plus n m
+def plus (n m : Nat) : Nat => elim n, m
+| zero, m => m
+| suc n, m => suc $ plus n m
 
 def not (b : Bool) : Bool => elim b
 | True => False

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -41,7 +41,7 @@ replLoop = do
 		| Left err => putErr prettyParsingError err
 	let tm = cast raw
 	state <- get CheckState
-	t <- infer' tm `handleErr` putErr prettyCheckError
+	t <- infer (MkEnv state.topEnv []) state.topCtx tm `handleErr` putErr prettyCheckError
 	let env = MkEnv state.topEnv []
 	ty <- runEval quote env t `handleErr` putErr prettyCheckError
 	v <- runEval nf env tm `handleErr` putErr prettyCheckError

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -41,7 +41,7 @@ replLoop = do
 		| Left err => putErr prettyParsingError err
 	let tm = cast raw
 	state <- get CheckState
-	t <- infer (MkEnv state.topEnv []) state.topCtx tm `handleErr` putErr prettyCheckError
+	(_, t) <- infer (MkEnv state.topEnv []) state.topCtx tm `handleErr` putErr prettyCheckError
 	let env = MkEnv state.topEnv []
 	ty <- runEval quote env t `handleErr` putErr prettyCheckError
 	v <- runEval nf env tm `handleErr` putErr prettyCheckError

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -150,17 +150,17 @@ mutual
 				let tm = Elim ts cases'
 				pure (tm, !(convTys (ElimInfer $ tm) env rhs_tys))
 				where
-					kk : Name -> Name -> List Name -> Maybe (List VTy) -> App e (Pat, List (Name, VTy))
-					kk head x [] Nothing = pure (PVar head, [(head, VData x)])
-					kk head _ vars (Just tys) = pure (PCons head vars, vars `zip` tys)
-					kk head x _ Nothing = report $ BadConstructor head x
+					elabPattern : Name -> Name -> List Name -> Maybe (List VTy) -> App e (Pat, List (Name, VTy))
+					elabPattern head x [] Nothing = pure (PVar head, [(head, VData x)])
+					elabPattern head _ vars (Just tys) = pure (PCons head vars, vars `zip` tys)
+					elabPattern head x _ Nothing = report $ BadConstructor head x
 
 					checkCase : Env -> Ctx -> List VTy -> ElimCase -> App e (List Pat, VTy)
 					checkCase env ctx (VData x :: ts) (PCons head vars :: pats, rhs) = do
 						-- TODO: to enable indexed data type, we will need to extend `findCtorSet` in the future
 						-- find a constructor set from definition context
 						cs <- findCtorSet x
-						(newPat, patternCtx) <- kk head x vars (lookup head cs)
+						(newPat, patternCtx) <- elabPattern head x vars (lookup head cs)
 						let patternEnv : LocalEnv = case newPat of
 						      PVar _ => [(head, VVar head)]
 						      PCons _ _ => (vars `zip` (map VVar vars))

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -110,11 +110,6 @@ mutual
 				updateCtx x a'
 
 	export
-	infer' : Check e => Tm -> App e VTy
-	infer' tm = do
-		state <- getState
-		infer (MkEnv state.topEnv []) state.topCtx tm
-
 	infer : Check e => Env -> Ctx -> Tm -> App e VTy
 	infer env ctx tm = go tm
 		where

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -130,7 +130,7 @@ mutual
 			go (Lam {}) = report (InferLam tm)
 			go (Pi x a b) = do
 				a <- check env ctx a VU
-				_ <- check (extendEnv env x (VVar x)) (extendCtx ctx x !(runEval eval env a)) b VU
+				b <- check (extendEnv env x (VVar x)) (extendCtx ctx x !(runEval eval env a)) b VU
 				pure (Pi x a b, VU)
 			go (Let x a t u) = do
 				a <- check env ctx a VU
@@ -194,9 +194,9 @@ mutual
 			go (Let x a t u) _ = do
 				a <- check env ctx a VU
 				a' <- runEval eval env a
-				t' <- check env ctx t a'
-				_ <- check (extendEnv env x !(runEval eval env t')) (extendCtx ctx x a') u a'
-				pure (Let x a t' u)
+				t <- check env ctx t a'
+				u <- check (extendEnv env x !(runEval eval env t)) (extendCtx ctx x a') u a'
+				pure (Let x a t u)
 			go _ expected = do
 				(t', inferred) <- infer env ctx t
 				Right convertable <- pure $ conv env inferred expected

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -148,7 +148,7 @@ mutual
 						pure ((pats', rhs) :: cases, ty :: ts))
 					([], []) cases
 				let tm = Elim ts cases'
-				pure (tm, !(convTys (ElimInfer $ tm) env rhs_tys))
+				pure (tm, !(convTys (ElimInfer tm) env rhs_tys))
 				where
 					elabPattern : Name -> Name -> List Name -> Maybe (List VTy) -> App e (Pat, List (Name, VTy))
 					elabPattern head x [] Nothing = pure (PVar head, [(head, VData x)])

--- a/src/Violet/Core.idr
+++ b/src/Violet/Core.idr
@@ -160,11 +160,11 @@ mutual
 						-- TODO: to enable indexed data type, we will need to extend `findCtorSet` in the future
 						-- find a constructor set from definition context
 						cs <- findCtorSet x
-						(newPat, patternCtx) <- elabPattern head x vars (lookup head cs)
-						let patternEnv : LocalEnv = case newPat of
+						(newPat, patCtx) <- elabPattern head x vars (lookup head cs)
+						let patEnv : LocalEnv = case newPat of
 						      PVar _ => [(head, VVar head)]
 						      PCons _ _ => (vars `zip` (map VVar vars))
-						(pats, ty) <- checkCase ({ local := patternEnv ++ env.local } env) (extendCtxWithBinds ctx $ patternCtx) ts (pats, rhs)
+						(pats, ty) <- checkCase ({ local := patEnv ++ env.local } env) (extendCtxWithBinds ctx $ patCtx) ts (pats, rhs)
 						pure (newPat :: pats, ty)
 					checkCase env ctx ([]) ([], rhs) = do
 						(_, ty) <- infer env ctx rhs

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -12,7 +12,10 @@ Name = String
 
 public export
 data Pat
-	= PCons Name (List Name)
+	-- var pattern
+	= PVar Name
+	-- ctor pattern
+	| PCons Name (List Name)
 
 mutual
 	||| The Core Term of violet language
@@ -50,6 +53,7 @@ mutual
 
 export
 Pretty Pat where
+	pretty (PVar x) = pretty x
 	pretty (PCons h vs) = pretty h <++> hsep (map pretty vs)
 
 export

--- a/src/Violet/Core/Term.idr
+++ b/src/Violet/Core/Term.idr
@@ -12,8 +12,7 @@ Name = String
 
 public export
 data Pat
-	= PVar Name
-	| PCons Name (List Name)
+	= PCons Name (List Name)
 
 mutual
 	||| The Core Term of violet language
@@ -26,11 +25,15 @@ mutual
 		| U                    -- U
 		| Pi Name Ty Ty        -- (x : a) → b
 		| Let Name Ty Tm Tm    -- let x : a = t; u
-		| Elim Tm (List (Pat, Tm))
+		| Elim (List Tm) (List ElimCase)
 
 	public export
 	Ty : Type
 	Ty = Tm
+
+	public export
+	ElimCase : Type
+	ElimCase = (List Pat, Tm)
 
 	public export
 	data DataCase = C Name (List Ty)
@@ -47,7 +50,6 @@ mutual
 
 export
 Pretty Pat where
-	pretty (PVar n) = pretty n
 	pretty (PCons h vs) = pretty h <++> hsep (map pretty vs)
 
 export
@@ -57,7 +59,7 @@ Pretty Tm where
 	pretty (Lam x t) = hsep ["λ", pretty x, "=>", pretty t]
 	pretty (Apply t u) = pretty t <++> case u of
 		SrcPos t => parens $ pretty t.val
-		Apply {}   => parens $ pretty u
+		Apply {} => parens $ pretty u
 		_        => pretty u
 	pretty U = "U"
 	pretty (Pi x a b) =
@@ -75,5 +77,5 @@ Pretty Tm where
 		<++> line
 		<++> vsep (map prettyCase cases)
 		where
-			prettyCase : (Pat, Tm) -> Doc ann
-			prettyCase (p, t) = pipe <++> pretty p <++> "=>" <++> pretty t
+			prettyCase : (List Pat, Tm) -> Doc ann
+			prettyCase (ps, t) = pipe <++> (encloseSep emptyDoc emptyDoc comma $ map pretty ps) <++> "=>" <++> pretty t

--- a/src/Violet/Core/Val.idr
+++ b/src/Violet/Core/Val.idr
@@ -97,6 +97,12 @@ eval env tm = case tm of
 	Elim ts cases => go !(for ts (eval env)) cases
 		where
 			matches : List Pat -> List Val -> Either EvalError LocalEnv
+			matches (PCons c [] :: next) (VCtor c' vals :: next') =
+				if not (c == c')
+					then pure $ (c, (VCtor c' vals)) :: !(matches next next')
+					else if 0 == length vals
+						then matches next next'
+						else Left OutOfCase
 			matches (PCons c names :: next) (VCtor c' vals :: next') =
 				if c == c' && length names == length vals
 					then pure $ !(matches next next') ++ (names `zip` vals)

--- a/src/Violet/Core/Val.idr
+++ b/src/Violet/Core/Val.idr
@@ -98,14 +98,28 @@ eval env tm = case tm of
 		where
 			matches : List Pat -> List Val -> Maybe LocalEnv
 			matches (PCons c [] :: next) (VCtor c' vals :: next') =
-				if not (c == c')
-					then pure $ (c, (VCtor c' vals)) :: !(matches next next')
-					else if 0 == length vals
-						then matches next next'
-						else Nothing
+				if c == c'
+					-- since the names are same, c must be an ctor pattern
+					--
+					-- e.g. with context `data Nat | zero | suc Nat`
+					--
+					--   zero matches zero
+					--
+					-- since this is a non-product ctor, therefore, has no environment introduced
+					then if 0 == length vals then matches next next' else Nothing
+					-- or it's a var pattern
+					--
+					-- e.g. with context `data Nat | zero | suc Nat`
+					--
+					--   m matches zero
+					else pure $ (c, (VCtor c' vals)) :: !(matches next next')
+			-- for non-destructable type like `Nat → Nat`, the only way can pattern matching on them is using var pattern
+			-- since type check should ensure the well behavior, here we just bind pattern var into local env
+			matches (PCons c [] :: next) (val :: next') = pure $ (c, val) :: !(matches next next')
+			-- for non-null case, must be ctor pattern
 			matches (PCons c names :: next) (VCtor c' vals :: next') =
 				if c == c' && length names == length vals
-					then pure $ !(matches next next') ++ (names `zip` vals)
+					then pure $ (names `zip` vals) ++ !(matches next next')
 					else Nothing
 			matches [] [] = pure []
 			matches _ _  = Nothing

--- a/src/Violet/Error/Check.idr
+++ b/src/Violet/Error/Check.idr
@@ -16,7 +16,7 @@ data CheckErrorKind
 	| NotADataType Name
 	| BadElimType (List Tm)
 	| ElimInfer Tm
-	| BadConstructor Name
+	| BadConstructor Name Name
 	| EvalE EvalError
 
 export
@@ -40,8 +40,14 @@ prettyCheckErrorKind (BadElimType tms) = annBold $ annColor Red $
 	vsep ["cannot eliminate type:", indent 4 $ hsep (map pretty tms)]
 prettyCheckErrorKind (ElimInfer tm) = annBold $ annColor Red $
 	vsep ["cannot infer this elimination:", indent 4 $ pretty tm]
-prettyCheckErrorKind (BadConstructor name) = annBold $ annColor Red $
-	hsep ["cannot find constructor in current context:", pretty name]
+prettyCheckErrorKind (BadConstructor name dataName) =
+	annBold $ (annColor Red $ "cannot find constructor")
+	<++> line
+	<++> hsep [
+		annColor Blue $ pretty name,
+		"is not a constructor of data type",
+		annColor Blue $ pretty dataName
+	]
 prettyCheckErrorKind (EvalE e) = prettyEvalError e
 
 public export

--- a/src/Violet/Error/Eval.idr
+++ b/src/Violet/Error/Eval.idr
@@ -15,4 +15,4 @@ export
 prettyEvalError : EvalError -> Doc AnsiStyle
 prettyEvalError (NoVar name) = annBold $ annColor Red $ hsep ["variable:", pretty name, "not found"]
 prettyEvalError (BadSpine tm) = annBold $ annColor Red $ hsep ["bad spine on:", pretty tm]
-prettyEvalError OutOfCase = annBold $ annColor Red $ "pattern matching out of case"
+prettyEvalError OutOfCase = annBold $ annColor Red $ "pattern matching eval out of case"

--- a/src/Violet/Lexer.idr
+++ b/src/Violet/Lexer.idr
@@ -27,7 +27,8 @@ data VTokenKind
 	| VTLambdaArrow       -- =>
 	| VTDollar            -- $
 	| VTIgnore            -- single line comment or whitespace
-	| VTModule             -- module
+	| VTModule            -- module
+	| VTComma             -- ,
 
 export
 Eq VTokenKind where
@@ -41,6 +42,7 @@ Eq VTokenKind where
 	(==) VTVerticalLine VTVerticalLine = True
 	(==) VTAssign VTAssign = True
 	(==) VTColon VTColon = True
+	(==) VTComma VTComma = True
 	(==) VTSemicolon VTSemicolon = True
 	(==) VTOpenP VTOpenP = True
 	(==) VTCloseP VTCloseP = True
@@ -63,6 +65,7 @@ Show VTokenKind where
 	show VTAssign       = "="
 	show VTColon        = ":"
 	show VTSemicolon    = ";"
+	show VTComma        = ","
 	show VTVerticalLine = "|"
 	show VTOpenP        = "("
 	show VTCloseP       = ")"
@@ -105,6 +108,7 @@ TokenKind VTokenKind where
 	tokValue VTDollar _ = ()
 	tokValue VTIgnore _ = ()
 	tokValue VTModule _ = ()
+	tokValue VTComma _ = ()
 
 ||| An identifier starts from alphabet
 ||| following with alphabet, number, and the below set
@@ -146,7 +150,8 @@ violetTokenMap = toTokenMap [
 		(exact "$", VTDollar),
 		(exact "(", VTOpenP),
 		(exact ")", VTCloseP),
-		(exact "=", VTAssign)
+		(exact "=", VTAssign),
+		(exact ",", VTComma)
 	] ++
 	[ (identifier, \s =>
 			case lookup s keywords of

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -100,7 +100,7 @@ mutual
 	tmElim : Rule Raw
 	tmElim = do
 		match VTElim
-		pure $ RElim !(many tm) !(many caseRule)
+		pure $ RElim !(sepBy (match VTComma) tm) !(many caseRule)
 
 ttmData : Rule TopLevelRaw
 ttmData = do

--- a/src/Violet/Parser.idr
+++ b/src/Violet/Parser.idr
@@ -88,19 +88,19 @@ mutual
 	patRule : Rule PatRaw
 	patRule = pure $ let (h ::: vs) = !(some (match VTIdentifier))
 		in if isNil vs then RPVar h else RPCons h vs
-	caseRule : Rule (PatRaw, Raw)
+	caseRule : Rule (List PatRaw, Raw)
 	caseRule = do
 		match VTVerticalLine
-		p <- patRule
+		ps <- sepBy (match VTComma) patRule
 		match VTLambdaArrow
-		(p,) <$> tm
+		(ps,) <$> tm
 	-- elim n
 	-- | C x => x
 	-- | z => z
 	tmElim : Rule Raw
 	tmElim = do
 		match VTElim
-		pure $ RElim !tm !(many caseRule)
+		pure $ RElim !(many tm) !(many caseRule)
 
 ttmData : Rule TopLevelRaw
 ttmData = do

--- a/src/Violet/Syntax.idr
+++ b/src/Violet/Syntax.idr
@@ -45,7 +45,7 @@ mutual
 		-- elim trichotomy a b
 		-- | greater _ => u1
 		-- | less p | equals p => f p
-		| RElim Raw (List (PatRaw, Raw))
+		| RElim (List Raw) (List (List PatRaw, Raw))
 
 	public export
 	RTy : Type
@@ -59,7 +59,7 @@ data ModuleRaw = MkModuleRaw ModuleInfoRaw (List TopLevelRaw)
 
 export
 Cast PatRaw Pat where
-	cast (RPVar n) = PVar n
+	cast (RPVar n) = PCons n []
 	cast (RPCons h vs) = PCons h vs
 
 export
@@ -71,7 +71,7 @@ Cast Raw Tm where
 	cast RU = U
 	cast (RPi x a b) = Pi x (cast a) (cast b)
 	cast (RLet x a t u) = Let x (cast a) (cast t) (cast u)
-	cast (RElim r cases) = Elim (cast r) $ map (bimap cast cast) cases
+	cast (RElim rs cases) = Elim (map cast rs) $ map (bimap (map cast) cast) cases
 
 export
 Cast TopLevelRaw Definition where


### PR DESCRIPTION
* syntax
    * multi-expressions as `elim` target
    * multi-patterns in each `elim` case
* `eval` semantic
* elaboration process that convert pattern to its correct case
    1. var pattern: `m` on `Nat`

        For example, the following `m` is not going to be destruct, but just bind
        ```
        elim n, m
        | zero, m => m
        | suc n, m => suc $ plus n m
        ```

    2. ctor pattern: `zero`, `suc n` on `Nat`

resolve #62

Signed-off-by: Lîm Tsú-thuàn <dannypsnl@gmail.com>