### PR TITLE
`def` elim syntax sugar

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -10,16 +10,16 @@ data Nat
 
 def id {A : U} (x : A) : A => x
 
-def zero? (n : Nat) : Bool => elim n
+def zero? (n : Nat) : Bool
 | zero => true
 | suc _ => false
 
-def plus (n m : Nat) : Nat => elim n, m
+def plus (n m : Nat) : Nat
 | n, zero => n
 | zero, m => m
 | suc n, suc m => suc $ suc $ plus n m
 
-def not (b : Bool) : Bool => elim b
+def not (b : Bool) : Bool
 | true => false
 | false => true
 
@@ -36,7 +36,7 @@ data Weekday
 | saturday
 | sunday
 
-def weekend? (day : Weekday) : Bool => elim day
+def weekend? (day : Weekday) : Bool
 | saturday | sunday => true
 | _ => false
 


### PR DESCRIPTION
Fix #64.

In this PR, we'll start to support the syntax sugar of `elim` so that users won't need to write `elim` explicitly.
Thus, in the `test.vt`, we can still pass the test by using the syntax.
