### PR TITLE
check modules in topological order

### DIFF
--- a/src/Libraries/Data/Graph.idr
+++ b/src/Libraries/Data/Graph.idr
@@ -1,0 +1,108 @@
+-- This file is copied from 
+-- https://github.com/idris-lang/Idris2/blob/main/src/Libraries/Data/Graph.idr
+
+{-
+Copyright (c) 2020 Edwin Brady
+    School of Computer Science, University of St Andrews
+All rights reserved.
+
+from https://github.com/idris-lang/Idris2/blob/main/LICENSE
+-}
+module Libraries.Data.Graph
+
+import Data.SortedMap
+import Data.SortedSet
+
+import Data.List1
+
+-- Mechanically transcribed from
+-- https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm#The_algorithm_in_pseudocode
+private
+record TarjanVertex where
+  constructor TV
+  index   : Int
+  lowlink : Int
+  inStack : Bool
+
+private
+record TarjanState cuid where
+  constructor TS
+  vertices           : SortedMap cuid TarjanVertex
+  stack              : List cuid
+  nextIndex          : Int
+  components         : List (List1 cuid)
+  impossibleHappened : Bool  -- we should get at least some indication of broken assumptions
+
+initial : Ord cuid => TarjanState cuid
+initial = TS empty [] 0 [] False
+
+adjust : k -> (v -> v) -> SortedMap k v -> SortedMap k v
+adjust k f m =
+  case lookup k m of
+    Nothing => m
+    Just v => insert k (f v) m
+
+||| Find strongly connected components in the given graph.
+|||
+||| Input: map from vertex X to all vertices Y such that there is edge X->Y
+||| Output: list of strongly connected components, ordered by output degree descending
+export
+tarjan : Ord cuid => SortedMap cuid (SortedSet cuid) -> List (List1 cuid)
+tarjan {cuid} deps = loop initial (SortedMap.keys deps)
+  where
+    strongConnect : TarjanState cuid -> cuid -> TarjanState cuid
+    strongConnect ts v =
+        let ts'' = case SortedMap.lookup v deps of
+              Nothing => ts'  -- no edges
+              Just edgeSet => loop ts' (SortedSet.toList edgeSet)
+          in case SortedMap.lookup v ts''.vertices of
+              Nothing => { impossibleHappened := True } ts''
+              Just vtv =>
+                if vtv.index == vtv.lowlink
+                  then createComponent ts'' v []
+                  else ts''
+      where
+        createComponent : TarjanState cuid -> cuid -> List cuid -> TarjanState cuid
+        createComponent ts v acc =
+          case ts.stack of
+            [] => { impossibleHappened := True } ts
+            w :: ws =>
+              let ts' : TarjanState cuid = {
+                      vertices $= adjust w { inStack := False },
+                      stack := ws
+                    } ts
+                in if w == v
+                  then { components $= ((v ::: acc) ::) } ts'  -- that's it
+                  else createComponent ts' v (w :: acc)
+
+        loop : TarjanState cuid -> List cuid -> TarjanState cuid
+        loop ts [] = ts
+        loop ts (w :: ws) =
+          loop (
+            case SortedMap.lookup w ts.vertices of
+              Nothing => let ts' = strongConnect ts w in
+                case SortedMap.lookup w ts'.vertices of
+                  Nothing => { impossibleHappened := True } ts'
+                  Just wtv => { vertices $= adjust v { lowlink $= min wtv.lowlink } } ts'
+
+              Just wtv => case wtv.inStack of
+                False => ts  -- nothing to do
+                True => { vertices $= adjust v { lowlink $= min wtv.index } } ts
+          ) ws
+
+        ts' : TarjanState cuid
+        ts' = {
+            vertices  $= SortedMap.insert v (TV ts.nextIndex ts.nextIndex True),
+            stack     $= (v ::),
+            nextIndex $= (1+)
+          } ts
+
+    loop : TarjanState cuid -> List cuid -> List (List1 cuid)
+    loop ts [] =
+      if ts.impossibleHappened
+        then []
+        else ts.components
+    loop ts (v :: vs) =
+      case SortedMap.lookup v ts.vertices of
+        Just _ => loop ts vs  -- done, skip
+        Nothing => loop (strongConnect ts v) vs

--- a/src/Main.idr
+++ b/src/Main.idr
@@ -6,6 +6,7 @@ import System.Path
 import Data.String
 import Data.SortedSet
 import Data.SortedMap
+import Libraries.Data.Graph
 import Control.App
 import Control.App.Handler
 import Control.App.Console
@@ -65,15 +66,27 @@ parseDepModules root acc (moduleName :: rest) =
 			let acc' = insert moduleName (raw, imports, source) acc
 			parseDepModules root acc' (rest ++ Data.SortedSet.toList imports)
 
+
 loadModuleFile : (PrimIO e, FileIO (IOError :: e)) => String -> App e CheckState
 loadModuleFile filename = do
 	-- TOOD: make root folder configerable
-	modules <- parseDepModules "./example" empty $ singleton filename
-	(raw, source) <-
-		case lookup filename modules of
-				Nothing => parseModuleFile filename -- fallback
-				Just (raw, imports, source) => pure (raw, source)
-	checkMod filename source raw
+	let rootPath = "./example"
+	modules <- parseDepModules rootPath empty $ singleton filename
+	let topoSortedLists = tarjan $ (\(_, imports, _) => imports) <$> modules
+	let dummyCheckState = checkState $ ctxFromFile "dummy_filename" "dummy_source"
+	let
+		go : CheckState -> List1 Name -> App e CheckState
+		go _ component = do
+			-- currently only allow one module per component
+			let moduleName = head component
+			let currFilename = moduleNameToFilepath rootPath moduleName
+			(raw, source) <-
+				case SortedMap.lookup moduleName modules of
+					Nothing => parseModuleFile currFilename -- fallback
+					Just (raw, _, source) => pure (raw, source)
+			primIO $ putStrLn $ "checking module " ++ moduleName
+			checkMod currFilename source raw
+	foldlM go dummyCheckState $ List.reverse topoSortedLists
 
 putCtx : PrimIO e => CheckState -> App e ()
 putCtx state = do


### PR DESCRIPTION
In this PR:

1. topo sort
2. check modules in that order

Next:

- propagate ctx/env

```
%  ./build/exec/violet check AModule 
parse module ./example/AModule.vt
parse module ./example/Base.vt
parse module ./example/Lib.vt
parse module ./example/Core.vt
checking module Core
checking module Base
checking module Lib
checking module AModule
Nat : U
zero : Nat
suc : Nat → Nat
id : {A : U} → (x : A) → A
main : Nat
```