### PR TITLE
[module_system] propagate check state while building multiple modules

### DIFF
--- a/example/AModule.vt
+++ b/example/AModule.vt
@@ -3,11 +3,9 @@ module AModule
 import Lib
 import Base
 
-data Nat
-| zero
-| suc Nat
-
 def id {A : U} (x : A) : A => x
+
+def addOne (x: Nat) : Nat => suc x
 
 def main : Nat =>
 	let one : Nat = suc zero;

--- a/example/Core.vt
+++ b/example/Core.vt
@@ -1,1 +1,5 @@
 module Core
+
+data Nat
+| zero
+| suc Nat

--- a/src/Violet/Core/Elab.idr
+++ b/src/Violet/Core/Elab.idr
@@ -18,6 +18,12 @@ checkState : Ctx -> CheckState
 checkState ctx = MkCheckState ctx [] [] emptyMetaCtx
 
 export
+initCheckStateWithCarriedState : CheckState -> Ctx -> CheckState
+initCheckStateWithCarriedState carriedCheckState ctx =
+  { topCtx := { map := carriedCheckState.topCtx.map } ctx
+  } carriedCheckState
+
+export
 interface Has [Exception CheckError, State CheckState CheckState] e => Elab e where
   getState : App e CheckState
   putState : CheckState -> App e ()


### PR DESCRIPTION
It's the easiest way to propagate generated CheckState (env, ctx and other etc.)

```
% ./build/exec/violet check AModule  
parse module ./example/AModule.vt
parse module ./example/Base.vt
parse module ./example/Lib.vt
parse module ./example/Core.vt
checking module Core
checking module Base
checking module Lib
checking module AModule
Nat : U
zero : Nat
suc : Nat → Nat
id : {A : U} → (x : A) → A
addOne : (x : Nat) → Nat <---- added for making sure it does do typecheck
main : Nat
```

We probably should make it more sophisticated, but this PR should unblock any works needs module system

