### PR TITLE
sigma type & pair

### DIFF
--- a/Tests/Parsing.lean
+++ b/Tests/Parsing.lean
@@ -36,5 +36,15 @@ def main : IO UInt32 :=
           .app .explicit (.var "a")
             (.app .explicit
               (.app .explicit (.var "b") (.var "c"))
-              (.var "d"))))
+              (.var "d")))),
+      ← lspecIO $ group "pair" $
+      test "base case"
+        (term.run "(a, b)" == .ok (.pair (.var "a") (.var "b"))),
+    ← lspecIO $ group "sigma type" $
+      test "base case"
+        (term.run "(x : A) × B" == .ok (.sigma "x" (.var "A") (.var "B")))
+      $ test "base case 2"
+        (term.run "(x : A) ** B" == .ok (.sigma "x" (.var "A") (.var "B")))
+      $ test "product type abbreviation"
+        (term.run "A × B" == .ok (.sigma "_" (.var "A") (.var "B")))
   ].foldl (λ acc x => acc + x) 0

--- a/Violet/Ast/Core.lean
+++ b/Violet/Ast/Core.lean
@@ -30,10 +30,12 @@ inductive Tm
   | type
   | meta (mvar : MetaVar)
   | var (name : Ix)
-  | app (fn : Tm) (arg : Tm)
-  | pi (name : String) (mode : Surface.Mode) (ty : Tm) (body : Tm)
+  | app (fn arg : Tm)
+  | pi (name : String) (mode : Surface.Mode) (ty body : Tm)
   | lam (name : String) (mode : Surface.Mode) (body : Tm)
-  | «let» (name : String) (ty : Tm) (val : Tm) (body : Tm)
+  | sigma (name : String) (ty body : Tm)
+  | pair (fst snd : Tm)
+  | «let» (name : String) (ty val body : Tm)
   | «match» (target : Tm) (cases : Array (Pattern × Tm))
   deriving Repr, Inhabited, BEq
 abbrev Typ := Tm

--- a/Violet/Ast/Surface.lean
+++ b/Violet/Ast/Surface.lean
@@ -23,6 +23,8 @@ inductive Tm : Type
   | app (mode : Mode) (fn : Tm) (arg : Tm)
   | pi (mode : Mode) (name : String) (ty : Tm) (body : Tm)
   | lam (mode : Mode) (name : String) (body : Tm)
+  | sigma (name : String) (ty : Tm) (body : Tm)
+  | pair (fst snd : Tm)
   | hole
   deriving Inhabited
 instance : Coe String Tm where
@@ -45,6 +47,8 @@ instance : ToString Pattern where
 
 partial def Tm.toString : Tm → String
   | .src _ _ tm => tm.toString
+  | .pair fst snd => s!"({fst.toString}, {snd.toString})"
+  | .sigma name ty body => s!"({name} : {ty.toString}) × {body.toString}"
   | .lam .implicit p body => "λ" ++ "{" ++ p ++ "}" ++ s!" => {body.toString}"
   | .lam .explicit p body => s!"λ {p} => {body.toString}"
   | .pi .implicit p ty body =>

--- a/Violet/Core/Context.lean
+++ b/Violet/Core/Context.lean
@@ -59,6 +59,8 @@ partial def ElabContext.showPat (ctx : ElabContext) (pat : Pattern) : String :=
   name ++ " " ++ toString pat.vars
 
 partial def ElabContext.showTm (ctx : ElabContext) : Tm → String
+  | .sigma x a b => s!"({x} : {ctx.showTm a}) × {ctx.showTm b}"
+  | .pair fst snd => s!"({ctx.showTm fst}, {ctx.showTm snd})"
   | .lam p .implicit body => "λ " ++ "{" ++ p ++ "}" ++ s!" => {ctx.showTm body}"
   | .lam p .explicit body => s!"λ {p} => {ctx.showTm body}"
   | .pi p .implicit ty body =>

--- a/Violet/Core/Elaboration.lean
+++ b/Violet/Core/Elaboration.lean
@@ -119,7 +119,10 @@ def ElabContext.check [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
     let t ← (ctx.bind x a).check t (← b.apply ctx.lvl.toNat)
     return .lam x .implicit t
   -- pair has a sigma type
-  | .pair fst snd, t => sorry
+  | .pair fst snd, .sigma _ a b =>
+    let fst' ← ctx.check fst a
+    let snd' ← ctx.check snd (← b.apply <| ← ctx.env.eval fst')
+    return .pair fst' snd'
   | .let x a t u, a' =>
     let a ← ctx.check a .type 
     let va ← ctx.env.eval a

--- a/Violet/Core/Elaboration.lean
+++ b/Violet/Core/Elaboration.lean
@@ -78,6 +78,8 @@ def ElabContext.infer [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
     let a' ← ctx.check a .type
     let b' ← (ctx.bind x (← ctx.env.eval a')).check b .type
     return (.pi x mode a' b', .type)
+  -- infer `(x : a) × b`
+  | .sigma x a b => sorry
   | .let x a t u =>
     let a ← ctx.check a .type
     let va ← ctx.env.eval a
@@ -96,7 +98,8 @@ def ElabContext.infer [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
   --
   -- The first one cannot be inferred, but the second one can.
   | .lam .. => throw "cannot infer lambda without type annotation"
-  | .match _ _ => throw "cannot infer pattern matching"
+  | .pair .. => throw "cannot infer pair"
+  | .match .. => throw "cannot infer pattern matching"
 
 partial
 def ElabContext.check [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
@@ -112,6 +115,8 @@ def ElabContext.check [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
   | t, .pi x .implicit a b =>
     let t ← (ctx.bind x a).check t (← b.apply ctx.lvl.toNat)
     return .lam x .implicit t
+  -- pair has a sigma type
+  | .pair fst snd, t => sorry
   | .let x a t u, a' =>
     let a ← ctx.check a .type 
     let va ← ctx.env.eval a

--- a/Violet/Core/Elaboration.lean
+++ b/Violet/Core/Elaboration.lean
@@ -79,7 +79,10 @@ def ElabContext.infer [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
     let b' ← (ctx.bind x (← ctx.env.eval a')).check b .type
     return (.pi x mode a' b', .type)
   -- infer `(x : a) × b`
-  | .sigma x a b => sorry
+  | .sigma x a b =>
+    let a' ← ctx.check a .type 
+    let b' ← (ctx.bind x (← ctx.env.eval a')).check b .type
+    return (.sigma x a' b', .type)
   | .let x a t u =>
     let a ← ctx.check a .type
     let va ← ctx.env.eval a

--- a/Violet/Core/Unification.lean
+++ b/Violet/Core/Unification.lean
@@ -55,6 +55,11 @@ def rename [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
         .pi x mode
           <$> go pren a
           <*> go pren.lift (← b.apply pren.cod.toNat)
+      | .pair a b => .pair <$> go pren a <*> go pren b
+      | .sigma x a b =>
+        .sigma x
+          <$> go pren a
+          <*> go pren.lift (← b.apply pren.cod.toNat)
       | .type => return .type
 
 def lams (l : Lvl) (t : Tm) : Tm := Id.run do
@@ -80,6 +85,12 @@ partial def unify [Monad m] [MonadState MetaCtx m] [MonadExcept String m]
   match ← force l, ← force r with
   | .lam _ _ t, .lam _ _ t' =>
     unify (.lvl <| lvl.toNat + 1) (← t.apply lvl.toNat) (← t'.apply lvl.toNat)
+  | .pair a b, .pair a' b' =>
+    unify lvl a a'
+    unify lvl b b'
+  | .sigma _ a b, .sigma _ a' b' =>
+    unify lvl a a'
+    unify (.lvl <| lvl.toNat + 1) (← b.apply lvl.toNat) (← b'.apply lvl.toNat)
   | .lam _ _ t', t | t, .lam _ _ t' =>
     unify (.lvl <| lvl.toNat + 1) (← t.apply lvl.toNat) (← t'.apply lvl.toNat)
   | .pi _ mode a b, .pi _ mode' a' b' =>

--- a/Violet/Core/Value.lean
+++ b/Violet/Core/Value.lean
@@ -31,6 +31,8 @@ Let's say we have usual `Nat` definition, then `suc n` is `rigid`, but `a n` is 
 inductive Val
   | flex (head : MetaVar) (body : Spine)
   | rigid (head : Lvl) (body : Spine)
+  | pair (fst snd : Val)
+  | sigma (name : String) (ty : Val) (clos : Closure)
   | lam (name : String) (mode : Surface.Mode) (clos : Closure)
   | pi (name : String) (mode : Surface.Mode) (ty : Val) (clos : Closure)
   | type

--- a/Violet/Parser.lean
+++ b/Violet/Parser.lean
@@ -98,7 +98,9 @@ mutual
     <|> kwTyp <|> hole <|> var
     <|> parsePi .implicit braces
     <|> (do
-      let r ← tryP <| pair <|> parens term
+      let r ← tryP <| pair
+      if r.isSome then return r.get!
+      let r ← tryP <| parens term
       if r.isSome then return r.get!
       let r ← tryP parseSigma
       if r.isSome then return r.get!

--- a/example/test.vt
+++ b/example/test.vt
@@ -49,3 +49,6 @@ match b
 -- | suc n => suc $ plus n m
 
 def main : NoB false => not <| zero? (suc zero)
+
+def test_pair : Nat × Nat => (zero, zero)
+def test_pair2 : Nat × Bool => (zero, false)


### PR DESCRIPTION
update parser for sigma concept
* parsing pair syntax `(t, u)`
* parsing sigma syntax (x : a) × b or (x : a) ** b
* parsing product type abbreviation A × B

elaboration
* make sure no infer pair
* check pair has sigma type

eval
* pair/sigma core term
* pair/sigma value
* eval pair/sigma
* quoting pair/sigma

unification
* unify top pair/sigma
* partial rename pair/sigma