### PR TITLE
resolve recursive definition (one level)

### DIFF
--- a/example/test.vt
+++ b/example/test.vt
@@ -47,10 +47,11 @@ match b
 | true => Nat
 | false => Bool
 
--- def plus (n m : Nat) : Nat =>
--- match n
--- | zero => m
--- | suc n => suc $ plus n m
+def plus (n m : Nat) : Nat =>
+match n
+| zero => m
+| suc n => suc <| plus n m
+def example : Nat => plus (suc (suc zero)) (suc zero)
 
 def main : NoB false => not <| zero? (suc zero)
 


### PR DESCRIPTION
In Violet.lean:35 to 40

Recursive relation is came from recursive definition of function, if we have `def f` calling `f` in its body, to check the definition, we can simply simply bind `f : ?` in context, `?` is the whole type but we don't care concrete type value.

After checking we have no need to expand our lambda term, and hence, now we are trying to reference to `f` itself, but in `eval`, lambda already captured the previous environment. Here, we make a trick to extract `f`'s closure if it's a lambda, then put new environment into it.

But here we only has a wrong implementation, the problem is we need to construct new environment with new type checked value, and in value, we need the new environment.

Next solution should try:

I can imagine our above trick should also replace variable with index `0` should get replaced with new core.term: `recur-point`, when recur-point is executing, `eval` will check if it has recur point to run, by `Env` should record the recur-lambda