### PR TITLE
fix: update record syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ match n
 | zero => true
 | suc _ => false
 
-record T {
-  a : Nat,
-  b : Bool,
-}
+record T where
+  a : Nat;
+  b : Bool;
 
 def t (x : Nat) : T => (x, zero? x)
 ```


### PR DESCRIPTION
This was missing in #111.

As we've changed the syntax, the example code in README should be updated as well.